### PR TITLE
Fixed problem with emails not sending body text

### DIFF
--- a/wildlifelicensing/apps/emails/emails.py
+++ b/wildlifelicensing/apps/emails/emails.py
@@ -10,7 +10,7 @@ logger = logging.getLogger('log')
 def _render(template, context):
     if isinstance(context, dict):
         context = Context(context)
-    if not isinstance(template, Template):
+    if isinstance(template, six.string_types):
         template = Template(template)
     return template.render(context)
 


### PR DESCRIPTION
The line

`if not isinstance(template, Template):`

doesn't work as expected because the type returned from loader.get_template is of type django.template.backends.django.Template rather than django.Template.base.template. As such is was creating a Template with a Template as the argument which doesn't render.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/ledger/50)
<!-- Reviewable:end -->
