### PR TITLE
Preproduction fixes

### DIFF
--- a/ledger/templates/403.html
+++ b/ledger/templates/403.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+{% block content %}
+
+<h2>{% trans 'Permission denied.' %}</h2>
+
+<p>{% trans "We're sorry but you are not permitted to access this page." %}</p>
+<a href="/">Click here to return to the home page.</a>
+{% endblock %}

--- a/ledger/templates/500.html
+++ b/ledger/templates/500.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+{% block content %}
+
+<h2>{% trans 'Server Error!' %}</h2>
+
+<p>{% trans "We're sorry, but an error occured while processing your request." %}</p>
+<a href="/">Click here to return to the home page.</a>
+{% endblock %}

--- a/wildlifelicensing/apps/applications/views/conditions.py
+++ b/wildlifelicensing/apps/applications/views/conditions.py
@@ -34,11 +34,11 @@ class EnterConditionsView(OfficerRequiredMixin, TemplateView):
         kwargs['action_url'] = reverse('wl_applications:submit_conditions', args=[application.pk])
 
         if application.proxy_applicant is None:
-            to = application.applicant_profile.user.email
+            to = application.applicant_profile.user.get_full_name()
         else:
-            to = application.proxy_applicant.email
+            to = application.proxy_applicant.get_full_name()
 
-        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to, fromm=self.request.user.email)
+        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to, fromm=self.request.user.get_full_name())
 
         return super(EnterConditionsView, self).get_context_data(**kwargs)
 

--- a/wildlifelicensing/apps/applications/views/issue.py
+++ b/wildlifelicensing/apps/applications/views/issue.py
@@ -49,7 +49,7 @@ class IssueLicenceView(OfficerRequiredMixin, TemplateView):
         else:
             to = application.proxy_applicant
 
-        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to.email, fromm=self.request.user.email)
+        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to.get_full_name(), fromm=self.request.user.get_full_name())
 
         return super(IssueLicenceView, self).get_context_data(**kwargs)
 
@@ -128,11 +128,11 @@ class IssueLicenceView(OfficerRequiredMixin, TemplateView):
             purposes = '\n\n'.join(Assessment.objects.filter(application=application).values_list('purpose', flat=True))
 
             if application.proxy_applicant is None:
-                to = application.applicant_profile.user.email
+                to = application.applicant_profile.user.get_full_name()
             else:
-                to = application.proxy_applicant.email
+                to = application.proxy_applicant.get_full_name()
 
-            log_entry_form = CommunicationsLogEntryForm(to=to, fromm=self.request.user.email)
+            log_entry_form = CommunicationsLogEntryForm(to=to, fromm=self.request.user.get_full_name())
 
             return render(request, self.template_name, {'application': serialize(application, posthook=format_application),
                                                         'issue_licence_form': IssueLicenceForm(purpose=purposes),

--- a/wildlifelicensing/apps/applications/views/process.py
+++ b/wildlifelicensing/apps/applications/views/process.py
@@ -83,11 +83,11 @@ class ProcessView(OfficerOrAssessorRequiredMixin, TemplateView):
         kwargs['amendment_request_form'] = AmendmentRequestForm(application=application, officer=self.request.user)
 
         if application.proxy_applicant is None:
-            to = application.applicant_profile.user.email
+            to = application.applicant_profile.user.get_full_name()
         else:
-            to = application.proxy_applicant.email
+            to = application.proxy_applicant.get_full_name()
 
-        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to, fromm=self.request.user.email)
+        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to, fromm=self.request.user.get_full_name())
 
         return super(ProcessView, self).get_context_data(**kwargs)
 

--- a/wildlifelicensing/apps/applications/views/view.py
+++ b/wildlifelicensing/apps/applications/views/view.py
@@ -72,6 +72,7 @@ class AddApplicationLogEntryView(OfficerRequiredMixin, View):
                 'officer': officer,
                 'customer': customer,
                 'application': application,
+                'type': form.cleaned_data['type'],
                 'text': form.cleaned_data['text'],
                 'subject': form.cleaned_data['subject'],
                 'to': form.cleaned_data['to'],

--- a/wildlifelicensing/apps/customer_management/views/customer.py
+++ b/wildlifelicensing/apps/customer_management/views/customer.py
@@ -147,7 +147,7 @@ class CustomerLookupView(OfficerRequiredMixin, base.TableBaseView):
 
             kwargs['customer'] = customer
 
-            kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=customer.email, fromm=self.request.user.email)
+            kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=customer.get_full_name(), fromm=self.request.user.get_full_name())
 
             context = super(CustomerLookupView, self).get_context_data(**kwargs)
 

--- a/wildlifelicensing/apps/main/management/commands/load_fixtures.py
+++ b/wildlifelicensing/apps/main/management/commands/load_fixtures.py
@@ -8,6 +8,7 @@ class Command(BaseCommand):
     fixtures = ['conditions',
                 'groups',
                 'licences',
+                'default-conditions',
                 'returns']
 
     def handle(self, *args, **options):

--- a/wildlifelicensing/apps/main/management/commands/load_fixtures.py
+++ b/wildlifelicensing/apps/main/management/commands/load_fixtures.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+from django.core.management import call_command
+
+
+class Command(BaseCommand):
+    help = 'Load all the fixtures'
+
+    fixtures = ['conditions',
+                'groups',
+                'licences',
+                'returns']
+
+    def handle(self, *args, **options):
+        for fixture in self.fixtures:
+            print('load {}'.format(fixture))
+            call_command('loaddata', fixture)

--- a/wildlifelicensing/apps/main/pdf.py
+++ b/wildlifelicensing/apps/main/pdf.py
@@ -193,7 +193,6 @@ def _create_licence(licence_buffer, licence, application, site_url, original_iss
         for location in licence.locations.split('\r\n'):
             if location:
                 locations.append(Paragraph(location, styles['Left']))
-                locations.append(Spacer(1, SECTION_BUFFER_HEIGHT))
 
         elements.append(Table([[Paragraph('Locations', styles['BoldLeft']), locations]],
                               colWidths=(100, PAGE_WIDTH - (2 * PAGE_MARGIN) - 100),

--- a/wildlifelicensing/apps/main/pdf.py
+++ b/wildlifelicensing/apps/main/pdf.py
@@ -3,7 +3,7 @@ import os
 from io import BytesIO
 from reportlab.lib import enums
 from reportlab.lib.pagesizes import A4
-from reportlab.platypus import BaseDocTemplate, PageTemplate, Frame, Paragraph, Spacer, Table, TableStyle, ListFlowable
+from reportlab.platypus import BaseDocTemplate, PageTemplate, Frame, Paragraph, Spacer, Table, TableStyle, ListFlowable, KeepTogether
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.utils import ImageReader
 
@@ -207,11 +207,14 @@ def _create_licence(licence_buffer, licence, application, site_url, original_iss
                               colWidths=(100, PAGE_WIDTH - (2 * PAGE_MARGIN) - 100),
                               style=licence_table_style))
 
+    # delegation holds the dates, licencee and issuer details.
+    delegation = []
+
     # dates and licensing officer
     dates_licensing_officer_table_style = TableStyle([('VALIGN', (0, 0), (-2, -1), 'TOP'),
                                                       ('VALIGN', (0, 0), (-1, -1), 'BOTTOM')])
 
-    elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
+    delegation.append(Spacer(1, SECTION_BUFFER_HEIGHT))
     date_headings = [Paragraph('Date of Issue', styles['BoldLeft']), Paragraph('Valid From', styles['BoldLeft']),
                      Paragraph('Date of Expiry', styles['BoldLeft'])]
     date_values = [Paragraph(licence.issue_date.strftime(DATE_FORMAT), styles['Left']),
@@ -222,26 +225,28 @@ def _create_licence(licence_buffer, licence, application, site_url, original_iss
         date_headings.insert(0, Paragraph('Original Date of Issue', styles['BoldLeft']))
         date_values.insert(0, Paragraph(original_issue_date.strftime(DATE_FORMAT), styles['Left']))
 
-    elements.append(Table([[date_headings, date_values]],
-                          colWidths=(120, PAGE_WIDTH - (2 * PAGE_MARGIN) - 120),
-                          style=dates_licensing_officer_table_style))
+    delegation.append(Table([[date_headings, date_values]],
+                            colWidths=(120, PAGE_WIDTH - (2 * PAGE_MARGIN) - 120),
+                            style=dates_licensing_officer_table_style))
 
     # licensee details
-    elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
+    delegation.append(Spacer(1, SECTION_BUFFER_HEIGHT))
     address = application.applicant_profile.postal_address
     address_paragraphs = [Paragraph(address.line1, styles['Left']), Paragraph(address.line2, styles['Left']),
                           Paragraph(address.line3, styles['Left']),
                           Paragraph('%s %s %s' % (address.locality, address.state, address.postcode), styles['Left']),
                           Paragraph(address.country.name, styles['Left'])]
-    elements.append(Table([[[Paragraph('Licensee:', styles['BoldLeft']), Paragraph('Address', styles['BoldLeft'])],
+    delegation.append(Table([[[Paragraph('Licensee:', styles['BoldLeft']), Paragraph('Address', styles['BoldLeft'])],
                             [Paragraph(render_user_name(application.applicant_profile.user), styles['Left'])] + address_paragraphs]],
-                          colWidths=(120, PAGE_WIDTH - (2 * PAGE_MARGIN) - 120),
-                          style=licence_table_style))
+                            colWidths=(120, PAGE_WIDTH - (2 * PAGE_MARGIN) - 120),
+                            style=licence_table_style))
 
-    elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
-    elements.append(Paragraph('Issued by a Wildlife Licensing Officer of the Department of Parks and Wildlife '
-                              'under delegation from the Minister for Environment pursuant to section 133(1) '
-                              'of the Conservation and Land Management Act 1984.', styles['Left']))
+    delegation.append(Spacer(1, SECTION_BUFFER_HEIGHT))
+    delegation.append(Paragraph('Issued by a Wildlife Licensing Officer of the Department of Parks and Wildlife '
+                                'under delegation from the Minister for Environment pursuant to section 133(1) '
+                                'of the Conservation and Land Management Act 1984.', styles['Left']))
+
+    elements.append(KeepTogether(delegation))
 
     doc.build(elements)
 

--- a/wildlifelicensing/apps/returns/fixtures/returns.json
+++ b/wildlifelicensing/apps/returns/fixtures/returns.json
@@ -47,7 +47,8 @@
                                 "name": "LONGITUDE",
                                 "constraints": {
                                     "minimum": -180.0,
-                                    "maximum": 180.0
+                                    "maximum": 180.0,
+                                    "required": true
                                 }
                             },
                             {

--- a/wildlifelicensing/apps/returns/views.py
+++ b/wildlifelicensing/apps/returns/views.py
@@ -12,8 +12,6 @@ from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 from django.http.response import JsonResponse
 
-
-from jsontableschema.model import SchemaModel
 from preserialize.serialize import serialize
 
 from ledger.accounts.models import Document
@@ -237,7 +235,7 @@ class CurateReturnView(OfficerRequiredMixin, TemplateView):
         else:
             to = ret.proxy_customer
 
-        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to.email, fromm=self.request.user.email)
+        kwargs['log_entry_form'] = CommunicationsLogEntryForm(to=to.get_full_name(), fromm=self.request.user.get_full_name())
 
         return super(CurateReturnView, self).get_context_data(**kwargs)
 
@@ -326,6 +324,7 @@ class AddReturnLogEntryView(OfficerRequiredMixin, View):
                 'officer': officer,
                 'customer': customer,
                 'ret': ret,
+                'type': form.cleaned_data['type'],
                 'text': form.cleaned_data['text'],
                 'subject': form.cleaned_data['subject'],
                 'to': form.cleaned_data['to'],

--- a/wildlifelicensing/static/wl/js/base.js
+++ b/wildlifelicensing/static/wl/js/base.js
@@ -3,7 +3,8 @@ require(['jQuery', 'bootstrap'], function ($) { // bootstrap returns nothing so 
         $('[data-toggle="popover"]').each(function () {
             //the 'is' for buttons that trigger popups
             //the 'has' for icons within a button that triggers a popup
-            if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+            if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $(e.target).parents('.popover').length === 0 
+                    && $.contains(document, e.target)) {
                 $(this).popover('hide');
             }
         });


### PR DESCRIPTION
On licence PDF, licencee, dates and issuer all in one block that won't be split over two pages.

Fixed bug stopping pagination of communications log in popovers.

Comm log items now use names rather then emails for To/From

Management command for loading all fixtures.

Longitude now required field for returns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/ledger/64)
<!-- Reviewable:end -->
