### PR TITLE
Numerous Features

### DIFF
--- a/ledger/accounts/test_models.py
+++ b/ledger/accounts/test_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django_dynamic_fixture import get as get_ddf
-from ledger.accounts.models import EmailUser, Address
+from ledger.accounts.models import EmailUser, Address, Country
 
 
 class EmailUserTest(TestCase):
@@ -50,7 +50,8 @@ class AddressTest(TestCase):
 
     def setUp(self):
         super(AddressTest, self).setUp()
-        self.address1 = get_ddf(Address)
+        get_ddf(Country, iso_3166_1_a2='AU')
+        self.address1 = get_ddf(Address, country='AU')
 
     def test_prop_join_fields(self):
         """Test the Address join_fields property

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-cron==0.4.6
 django-dynamic-fixture>=1.9.0
 openpyxl==2.3.5
 datapackage>=0.6.1
-jsontableschema>=0.6.3
+jsontableschema==0.6.5
 python-dateutil==2.5.3
 py4j==0.10.2.1
 djangorestframework==3.4.0

--- a/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.html
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.html
@@ -18,7 +18,7 @@
     </p>
     <p></p>
     <p>
-        from Jim Sharp<br>
+        for Jim Sharp<br>
         DIRECTOR GENERAL
     </p>
     <p>

--- a/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.txt
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/licence_issued.txt
@@ -17,7 +17,7 @@ Yours sincerely
 
 
 
-from Jim Sharp
+for Jim Sharp
 
 DIRECTOR GENERAL
 

--- a/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.html
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.html
@@ -28,7 +28,7 @@
     </p>
     <p></p>
     <p>
-        from Jim Sharp<br>
+        for Jim Sharp<br>
         DIRECTOR GENERAL
     </p>
     <p>

--- a/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.txt
+++ b/wildlifelicensing/apps/applications/templates/wl/emails/renew_licence_notification.txt
@@ -21,7 +21,7 @@ Yours sincerely
 
 
 
-from Jim Sharp
+for Jim Sharp
 
 DIRECTOR GENERAL
 

--- a/wildlifelicensing/apps/applications/templates/wl/issue/issue_licence.html
+++ b/wildlifelicensing/apps/applications/templates/wl/issue/issue_licence.html
@@ -158,9 +158,15 @@
                                             <div class="form-group">
                                                 <label class="control-label" for="id_{{ item.name }}">{{ item.label }}</label>
                                                 {% include 'wl/issue/extracted_field.html' with field=item %}
+                                                {% if item.help_text %}
+                                                    <p class="help-block">{{ item.help_text }}</p>
+                                                {% endif %}
                                             </div>
                                         {% else %}
                                             <label class="control-label" for="id_{{ item.name }}">{{ item.label }}</label>
+                                            {% if item.help_text %}
+                                                <p class="help-block">{{ item.help_text }}</p>
+                                            {% endif %}
                                             {% for item_group in item.children %}
                                                 <div class="row">
                                                     {% with width=item_group|length|derive_col_width %}

--- a/wildlifelicensing/apps/applications/tests/helpers.py
+++ b/wildlifelicensing/apps/applications/tests/helpers.py
@@ -1,20 +1,22 @@
 from datetime import datetime
 
 from django.test import TestCase
-from django_dynamic_fixture import get as get_ddf
+from django_dynamic_fixture import G
 
 from django.core.urlresolvers import reverse, reverse_lazy
 
-from ledger.accounts.models import Profile
+from ledger.accounts.models import Profile, Address
 
 from wildlifelicensing.apps.applications.views.entry import LICENCE_TYPE_NUM_CHARS, LODGEMENT_NUMBER_NUM_CHARS
 from wildlifelicensing.apps.applications.models import Application, Assessment, Condition
 from wildlifelicensing.apps.main.tests.helpers import create_random_customer, get_or_create_licence_type, \
-    SocialClient, get_or_create_default_assessor_group, get_or_create_default_officer
+    SocialClient, get_or_create_default_assessor_group, get_or_create_default_officer, create_default_country
 
 
 def create_profile(user):
-    return get_ddf(Profile, user=user)
+    create_default_country()
+    address = G(Address, user=user, country='AU')
+    return G(Profile, adress=address, user=user)
 
 
 def create_application(user=None, **kwargs):
@@ -28,7 +30,7 @@ def create_application(user=None, **kwargs):
         kwargs['licence_type'] = get_or_create_licence_type()
     if 'data' not in kwargs:
         kwargs['data'] = {}
-    application = get_ddf(Application, **kwargs)
+    application = G(Application, **kwargs)
     return application
 
 

--- a/wildlifelicensing/apps/applications/tests/test_entry.py
+++ b/wildlifelicensing/apps/applications/tests/test_entry.py
@@ -19,6 +19,7 @@ class ApplicationEntryTestCase(TestCase):
     fixtures = ['licences.json', 'catalogue.json', 'partner.json']
 
     def setUp(self):
+        helpers.create_default_country()
         self.customer = get_or_create_default_customer()
 
         self.client = SocialClient()

--- a/wildlifelicensing/apps/applications/utils.py
+++ b/wildlifelicensing/apps/applications/utils.py
@@ -84,12 +84,7 @@ def _extract_licence_fields_from_item(item, data, licence_fields):
         if 'children' not in item:
             # label / checkbox types are extracted differently so skip here
             if item['type'] not in ('label', 'checkbox'):
-                licence_field = {
-                    'name': item['name'],
-                    'label': item['licenceFieldLabel'] if 'licenceFieldLabel' in item else item['label'],
-                    'type': item['type'],
-                    'readonly': item.get('isLicenceFieldReadonly', False)
-                }
+                licence_field = _create_licence_field(item)
 
                 if 'options' in item:
                     licence_field['options'] = item['options']
@@ -99,13 +94,8 @@ def _extract_licence_fields_from_item(item, data, licence_fields):
 
                 licence_fields.append(licence_field)
         else:
-            licence_field = {
-                'name': item['name'],
-                'label': item['licenceFieldLabel'] if 'licenceFieldLabel' in item else item['label'],
-                'type': item['type'],
-                'readonly': item.get('isLicenceFieldReadonly', False),
-                'children': []
-            }
+            licence_field = _create_licence_field(item)
+            licence_field['children'] = []
 
             child_data = _extract_item_data(item['name'], data)
 
@@ -139,13 +129,8 @@ def _extract_licence_fields_from_item(item, data, licence_fields):
 
 
 def _extract_label_and_checkboxes(current_item, items, data, licence_fields):
-    licence_field = {
-        'name': current_item['name'],
-        'label': current_item['licenceFieldLabel'] if 'licenceFieldLabel' in current_item else current_item['label'],
-        'type': current_item['type'],
-        'readonly': current_item.get('isLicenceFieldReadonly', False),
-        'options': []
-    }
+    licence_field = _create_licence_field(current_item)
+    licence_field['options'] = []
 
     # find index of first checkbox after checkbox label within current item list
     checkbox_index = 0
@@ -168,6 +153,16 @@ def _extract_label_and_checkboxes(current_item, items, data, licence_fields):
         checkbox_index += 1
 
     licence_fields.append(licence_field)
+
+
+def _create_licence_field(item):
+    return {
+        'name': item['name'],
+        'type': item['type'],
+        'label': item['licenceFieldLabel'] if 'licenceFieldLabel' in item else item['label'],
+        'help_text': item.get('licenceFieldHelpText', ''),
+        'readonly': item.get('isLicenceFieldReadonly', False)
+    }
 
 
 def _extract_item_data(name, data):

--- a/wildlifelicensing/apps/applications/views/entry.py
+++ b/wildlifelicensing/apps/applications/views/entry.py
@@ -196,6 +196,8 @@ class SelectLicenceTypeView(LoginRequiredMixin, TemplateView):
 
             application.licence_type = WildlifeLicenceType.objects.get(id=self.args[0])
 
+            application.data = None
+
             application.variants.clear()
 
             for index, variant_id in enumerate(request.GET.getlist('variants', [])):

--- a/wildlifelicensing/apps/main/fixtures/groups.json
+++ b/wildlifelicensing/apps/main/fixtures/groups.json
@@ -10,5 +10,11 @@
         "fields": {
             "name": "Assessors"
         }
+    },
+        {
+        "model": "auth.Group",
+        "fields": {
+            "name": "API"
+        }
     }
 ]

--- a/wildlifelicensing/apps/main/pdf.py
+++ b/wildlifelicensing/apps/main/pdf.py
@@ -415,7 +415,7 @@ def _create_letter_signature():
     signature_elements = []
     signature_elements.append(Paragraph('Yours sincerely', styles['LetterLeft']))
     signature_elements.append(Spacer(1, SECTION_BUFFER_HEIGHT * 4))
-    signature_elements.append(Paragraph('from Jim Sharp', styles['LetterLeft']))
+    signature_elements.append(Paragraph('for Jim Sharp', styles['LetterLeft']))
     signature_elements.append(Paragraph('DIRECTOR GENERAL', styles['LetterLeft']))
     signature_elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
 

--- a/wildlifelicensing/apps/main/pdf.py
+++ b/wildlifelicensing/apps/main/pdf.py
@@ -37,6 +37,7 @@ PAGE_WIDTH, PAGE_HEIGHT = A4
 
 DEFAULT_FONTNAME = 'Helvetica'
 BOLD_FONTNAME = 'Helvetica-Bold'
+ITALIC_FONTNAME = 'Helvetica-Oblique'
 BOLD_ITALIC_FONTNAME = 'Helvetica-BoldOblique'
 
 VERY_LARGE_FONTSIZE = 14
@@ -79,6 +80,8 @@ styles.add(ParagraphStyle(name='InfoTitleLargeRight', fontName=BOLD_FONTNAME, fo
                           rightIndent=PAGE_WIDTH / 10))
 styles.add(ParagraphStyle(name='BoldLeft', fontName=BOLD_FONTNAME, fontSize=MEDIUM_FONTSIZE, alignment=enums.TA_LEFT))
 styles.add(ParagraphStyle(name='BoldRight', fontName=BOLD_FONTNAME, fontSize=MEDIUM_FONTSIZE, alignment=enums.TA_RIGHT))
+styles.add(ParagraphStyle(name='ItalicLeft', fontName=ITALIC_FONTNAME, fontSize=MEDIUM_FONTSIZE, alignment=enums.TA_LEFT))
+styles.add(ParagraphStyle(name='ItalifRight', fontName=ITALIC_FONTNAME, fontSize=MEDIUM_FONTSIZE, alignment=enums.TA_RIGHT))
 styles.add(ParagraphStyle(name='Center', alignment=enums.TA_CENTER))
 styles.add(ParagraphStyle(name='Left', alignment=enums.TA_LEFT))
 styles.add(ParagraphStyle(name='Right', alignment=enums.TA_RIGHT))
@@ -264,6 +267,11 @@ def _layout_extracted_fields(extracted_fields):
                 elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
                 elements.append(Paragraph(field['label'], styles['BoldLeft']))
 
+                if field['help_text']:
+                    elements.append(Paragraph(field['help_text'], styles['ItalicLeft']))
+
+                elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
+
                 if field['type'] in ['text', 'text_area']:
                     elements += _layout_paragraphs(field['data'])
                 elif field['type'] in ['radiobuttons', 'select']:
@@ -276,12 +284,21 @@ def _layout_extracted_fields(extracted_fields):
                 if any([option.get('data', 'off') == 'on' for option in field['options']]):
                     elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
                     elements.append(Paragraph(field['label'], styles['BoldLeft']))
+
+                    if field['help_text']:
+                        elements.append(Paragraph(field['help_text'], styles['ItalicLeft']))
+
+                    elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
+
                     elements.append(Paragraph(', '.join([option['label'] for option in field['options']
                                                         if option.get('data', 'off') == 'on']),
                                     styles['Left']))
         else:
             elements.append(Spacer(1, SECTION_BUFFER_HEIGHT))
             elements.append(Paragraph(field['label'], styles['BoldLeft']))
+
+            if field['help_text']:
+                elements.append(Paragraph(field['help_text'], styles['ItalicLeft']))
 
             table_data = []
             for index, group in enumerate(field['children']):

--- a/wildlifelicensing/apps/main/tests/helpers.py
+++ b/wildlifelicensing/apps/main/tests/helpers.py
@@ -48,6 +48,12 @@ class TestData(object):
         'name': 'ass group',
         'email': 'assessor@test.com',
     }
+    DEFAULT_API_USER = {
+        'email': 'apir@test.com',
+        'first_name': 'api',
+        'last_name': 'user',
+        'dob': '1979-12-13',
+    }
 
 
 class SocialClient(Client):
@@ -114,6 +120,13 @@ def get_or_create_default_officer():
     user, created = get_or_create_user(TestData.DEFAULT_OFFICER['email'], TestData.DEFAULT_OFFICER)
     if created:
         add_to_group(user, 'Officers')
+    return user
+
+
+def get_or_create_api_user():
+    user, created = get_or_create_user(TestData.DEFAULT_API_USER['email'], TestData.DEFAULT_API_USER)
+    if created:
+        add_to_group(user, 'API')
     return user
 
 

--- a/wildlifelicensing/apps/main/tests/helpers.py
+++ b/wildlifelicensing/apps/main/tests/helpers.py
@@ -8,9 +8,9 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 from django.utils.encoding import smart_text
-from django_dynamic_fixture import get as get_ddf
+from django_dynamic_fixture import G
 
-from ledger.accounts.models import EmailUser, Profile, Address
+from ledger.accounts.models import EmailUser, Profile, Address, Country
 from wildlifelicensing.apps.main import helpers as accounts_helpers
 from wildlifelicensing.apps.main.models import WildlifeLicenceType, WildlifeLicence, AssessorGroup
 
@@ -76,6 +76,10 @@ class SocialClient(Client):
         self.get(reverse('accounts:logout'))
 
 
+def create_default_country():
+    return G(Country, iso_3166_1_a2='AU')
+
+
 def is_client_authenticated(client):
     return '_auth_user_id' in client.session
 
@@ -98,7 +102,7 @@ def get_or_create_user(email, defaults):
 
 
 def create_random_user():
-    return get_ddf(EmailUser, dob='1970-01-01')
+    return G(EmailUser, dob='1970-01-01')
 
 
 def create_random_customer():

--- a/wildlifelicensing/apps/main/tests/tests.py
+++ b/wildlifelicensing/apps/main/tests/tests.py
@@ -7,13 +7,14 @@ from django.test import TestCase
 
 from ledger.accounts.models import EmailUser, Profile
 from wildlifelicensing.apps.main.tests.helpers import SocialClient, get_or_create_default_customer, \
-    get_or_create_default_officer, TestData, upload_id
+    get_or_create_default_officer, TestData, upload_id, create_default_country
 
 TEST_ID_PATH = TestData.TEST_ID_PATH
 
 
 class AccountsTestCase(TestCase):
     def setUp(self):
+        create_default_country()
         self.customer = get_or_create_default_customer()
 
         self.officer = get_or_create_default_officer()

--- a/wildlifelicensing/apps/main/views.py
+++ b/wildlifelicensing/apps/main/views.py
@@ -190,15 +190,13 @@ class EditAccountView(CustomerRequiredMixin, TemplateView):
         original_last_name = emailuser.last_name
         emailuser_form = EmailUserForm(request.POST, instance=emailuser)
         if emailuser_form.is_valid():
-            emailuser = emailuser_form.save(commit=False)
+            emailuser = emailuser_form.save()
             is_name_changed = any([original_first_name != emailuser.first_name, original_last_name != emailuser.last_name])
 
             # send signal if either first name or last name is changed
             if is_name_changed:
                 messages.warning(request, "Please upload new identification after you changed your name.")
                 return redirect(self.identification_url)
-            elif not emailuser.identification:
-                messages.warning(request, "Please upload your identification.")
             else:
                 messages.success(request, "User account was saved.")
 

--- a/wildlifelicensing/apps/payments/utils.py
+++ b/wildlifelicensing/apps/payments/utils.py
@@ -35,7 +35,7 @@ def generate_product_code_variants(licence_type):
             return
 
         for variant in variant_group.variants.all():
-            variant_code = '{}_{}'.format(product_code, variant.product_code)
+            variant_code = '{} {}'.format(product_code, variant.product_code)
 
             __append_variant_codes(variant_code, variant_group.child, variant_codes)
 
@@ -50,8 +50,9 @@ def generate_product_code(application):
     product_code = application.licence_type.product_code
 
     if application.variants.exists():
-        product_code += '_' + '_'.join(application.variants.through.objects.filter(application=application).
-                                       order_by('order').values_list('variant__product_code', flat=True))
+        product_code = '{} {}'.format(product_code,
+                                      ' '.join(application.variants.through.objects.filter(application=application).
+                                               order_by('order').values_list('variant__product_code', flat=True)))
 
     return product_code
 

--- a/wildlifelicensing/apps/payments/views.py
+++ b/wildlifelicensing/apps/payments/views.py
@@ -98,7 +98,9 @@ class PaymentsReportView(View):
             data = {
                 'system': PAYMENT_SYSTEM_ID,
                 'start': start,
-                'end': end
+                'end': end,
+                'banked_start': start,
+                'banked_end': end
             }
             if 'items' in request.GET:
                 data['items'] = True

--- a/wildlifelicensing/apps/reports/templates/wl/reports.html
+++ b/wildlifelicensing/apps/reports/templates/wl/reports.html
@@ -125,7 +125,6 @@
                         <div class="col-md-8">
                             <button type=submit class="btn btn-primary pull-left" name="items">Generate Report By Accounts</button>
                             <button type=submit class="btn btn-primary pull-right" name="flat">Generate Report Flat</button>
-                            <hr>
                         </div>
                     </div>
                 </form>

--- a/wildlifelicensing/apps/returns/api/mixins.py
+++ b/wildlifelicensing/apps/returns/api/mixins.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
+
+from wildlifelicensing.apps.main.helpers import belongs_to
+
+
+def is_api_user(user):
+    return belongs_to(user, 'API') or user.is_superuser
+
+
+class APIUserRequiredMixin(UserPassesTestMixin):
+    """
+    Mixin uses for API view.
+    """
+    # we don't want to be redirected to login page.
+    raise_exception = True
+
+    def test_func(self):
+        return is_api_user(self.request.user)

--- a/wildlifelicensing/apps/returns/static/wl/js/return_table.js
+++ b/wildlifelicensing/apps/returns/static/wl/js/return_table.js
@@ -1,8 +1,80 @@
-define(['jQuery', 'datatables.net', 'datatables.bootstrap', 'datatables.datetime'], function ($) {
+define([
+    'jQuery',
+    'datatables.net',
+    'datatables.bootstrap',
+    'datatables.datetime',
+    'bootstrap-3-typeahead'
+], function ($) {
     "use strict";
 
+    function querySpecies(speciesType, search, callback) {
+        var url = '/taxonomy/species_name',
+            params = {},
+            promise;
+        if (speciesType) {
+            params.type = speciesType;
+        }
+        if (search) {
+            params.search = search;
+        }
+        url += '?' + $.param(params);
+        promise = $.get(url);
+        if (typeof callback === 'function') {
+            promise.then(callback);
+        }
+        return promise;
+    }
+
+    function setSpeciesValid($field, valid) {
+        var validClass = 'text-success';
+        if (valid) {
+            $field.addClass(validClass);
+        } else {
+            $field.removeClass(validClass);
+        }
+    }
+
+    function validateSpeciesField($field, speciesType) {
+        // Rules: if only one species is returned from the api we consider the name to be valid.
+        // Trick: the species can be recorded as: species_name (common name) in this case the search will fail
+        // (species_name or common name but not both). We get rid of anything in parenthesis.
+        var value = $field.val();
+        if (value) {
+            value = value.replace(/\s?\(.*\)/, '');
+            querySpecies(speciesType, value.trim(), function (data) {
+                var valid = data && data.length === 1;
+                setSpeciesValid($field, valid);
+            });
+        }
+    }
+
+    function initSpeciesFields($parent) {
+        var $species_fields = $parent.find('input[data-species]');
+        if ($species_fields.length > 0) {
+            $species_fields.each(function () {
+                var $field = $(this),
+                    speciesType = $field.attr('data-species'),
+                    value;
+                $field.typeahead({
+                    minLength: 2,
+                    items: 'all',
+                    source: function (query, process) {
+                        querySpecies(speciesType, query, function (data) {
+                            return process(data);
+                        });
+                    }
+                });
+                value = $field.val();
+                if (value) {
+                    // already some data. We try to validate.
+                    validateSpeciesField($field, speciesType);
+                }
+            });
+        }
+    }
+
     return {
-        initTables: function() {
+        initTables: function () {
             var $tables = $('.return-table'),
                 $curationForm = $('#curationForm');
 
@@ -13,7 +85,9 @@ define(['jQuery', 'datatables.net', 'datatables.bootstrap', 'datatables.datetime
                 info: false
             });
 
-            $('.add-return-row').click(function() {
+            initSpeciesFields($tables);
+
+            $('.add-return-row').click(function () {
                 var $tbody = $(this).parent().find('table').find('tbody'),
                     $row = $tbody.find('tr:first');
                 // clone the top row
@@ -25,14 +99,15 @@ define(['jQuery', 'datatables.net', 'datatables.bootstrap', 'datatables.datetime
 
                 // append cloned row
                 $tbody.append($rowCopy);
+                initSpeciesFields($rowCopy);
             });
 
-            $('#accept').click(function() {
+            $('#accept').click(function () {
                 $curationForm.append($('<input>').attr('name', 'accept').addClass('hidden'));
                 $curationForm.submit();
             });
 
-            $('#decline').click(function() {
+            $('#decline').click(function () {
                 $curationForm.append($('<input>').attr('name', 'decline').addClass('hidden'));
                 $curationForm.submit();
             });

--- a/wildlifelicensing/apps/returns/templates/wl/curate_return.html
+++ b/wildlifelicensing/apps/returns/templates/wl/curate_return.html
@@ -115,7 +115,7 @@
                                         <thead>
                                             <tr>
                                                 {% for header in table.headers %}
-                                                    <th>{{ header }}</th>
+                                                    <th>{{ header.title }}{% if header.required %} *{% endif %}</th>
                                                 {% endfor %}
                                             </tr>
                                         </thead>
@@ -123,10 +123,14 @@
                                             {% for row in table.data %}
                                                 <tr>
                                                     {% for header in table.headers %}
-                                                        {% with value=row|get_item:header|get_item:'value' error=row|get_item:header|get_item:'error' %}
+                                                        {% with value=row|get_item:header.title|get_item:'value' error=row|get_item:header.title|get_item:'error' %}
                                                             <td>
-                                                                <input name="{{ table.name }}::{{ header }}"
-                                                                       value="{{ value }}"/>
+                                                                <input name="{{ table.name }}::{{ header.title }}"
+                                                                       value="{{ value|default_if_none:"" }}"
+                                                                       {%  if header.species %}
+                                                                           data-species="{{ header.species }}"
+                                                                       {% endif %}
+                                                                />
                                                                 {% if error %}
                                                                     <div><span class="text-danger">{{ error }}</span>
                                                                     </div>

--- a/wildlifelicensing/apps/returns/templates/wl/enter_return.html
+++ b/wildlifelicensing/apps/returns/templates/wl/enter_return.html
@@ -18,7 +18,11 @@
 
 {% block requirements %}
     require(["{% static 'wl/js/return_table.js' %}"], function (returnTable) {
-    returnTable.initTables();
+        returnTable.initTables();
+        // disable form submit by 'enter' key
+        $(document).on("keypress", "form", function(event) {
+             return event.keyCode != 13;
+        });
     });
 {% endblock %}
 
@@ -120,7 +124,11 @@
                                                     {% with value=row|get_item:header.title|get_item:'value' error=row|get_item:header.title|get_item:'error' %}
                                                         <td>
                                                             <input name="{{ table.name }}::{{ header.title }}"
-                                                                   value="{{ value|default_if_none:"" }}"/>
+                                                                   value="{{ value|default_if_none:"" }}"
+                                                                   {%  if header.species %}
+                                                                       data-species="{{ header.species }}"
+                                                                   {% endif %}
+                                                            />
                                                             {% if error %}
                                                                 <div><span class="text-danger">{{ error }}</span></div>
                                                             {% endif %}
@@ -134,7 +142,11 @@
                                             <tr>
                                                 {% for header in table.headers %}
                                                     <td>
-                                                        <input name="{{ table.name }}::{{ header.title }}"/>
+                                                        <input name="{{ table.name }}::{{ header.title }}"
+                                                               {%  if header.species %}
+                                                                   data-species="{{ header.species }}"
+                                                               {% endif %}
+                                                        />
                                                     </td>
                                                 {% endfor %}
                                             </tr>

--- a/wildlifelicensing/apps/returns/tests/helpers.py
+++ b/wildlifelicensing/apps/returns/tests/helpers.py
@@ -1,6 +1,105 @@
+import copy
 from datetime import date, timedelta
 
 from wildlifelicensing.apps.returns.models import Return, ReturnType
+
+
+def clone(descriptor):
+    return copy.deepcopy(descriptor)
+
+
+BASE_CONSTRAINTS = {
+    "required": False
+}
+
+NOT_REQUIRED_CONSTRAINTS = {
+    "required": False
+}
+
+REQUIRED_CONSTRAINTS = {
+    "required": True
+}
+
+BASE_FIELD = {
+    "name": "Name",
+    "tile": "Title",
+    "type": "string",
+    "format": "default",
+    "constraints": clone(BASE_CONSTRAINTS)
+}
+
+GENERIC_SCHEMA = {
+    "fields": [
+        clone(BASE_FIELD)
+    ]
+}
+
+GENERIC_DATA_PACKAGE = {
+    "name": "test",
+    "resources": [
+        {
+            "name": "test",
+            "format": "CSV",
+            "title": "test",
+            "bytes": 0,
+            "mediatype": "text/csv",
+            "path": "test.csv",
+            "schema": clone(GENERIC_SCHEMA)
+        }
+    ],
+    "title": "Test"
+}
+
+SPECIES_NAME_FIELD = {
+    "name": "Species Name",
+    "type": "string",
+    "format": "default",
+    "constraints": {
+        "required": True
+    },
+    "wl": {
+        "type": "species"
+    }
+}
+
+LAT_LONG_OBSERVATION_SCHEMA = {
+    "fields": [
+        {
+            "name": "Observation Date",
+            "type": "date",
+            "format": "any",
+            "constraints": {
+                "required": True,
+            }
+        },
+        {
+            "name": "Latitude",
+            "type": "number",
+            "format": "default",
+            "constraints": {
+                "required": True,
+                "minimum": -90.0,
+                "maximum": 90.0,
+            }
+        },
+        {
+            "name": "Longitude",
+            "type": "number",
+            "format": "default",
+            "constraints": {
+                "required": True,
+                "minimum": -180.0,
+                "maximum": 180.0,
+            }
+        },
+    ]
+}
+
+SPECIES_SCHEMA = clone(LAT_LONG_OBSERVATION_SCHEMA)
+SPECIES_SCHEMA['fields'].append(clone(SPECIES_NAME_FIELD))
+
+SPECIES_DATA_PACKAGE = clone(GENERIC_DATA_PACKAGE)
+SPECIES_DATA_PACKAGE['resources'][0]['schema'] = clone(SPECIES_SCHEMA)
 
 
 def get_or_create_return_type(licence_type):

--- a/wildlifelicensing/apps/returns/tests/test_api.py
+++ b/wildlifelicensing/apps/returns/tests/test_api.py
@@ -1,0 +1,103 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from rest_framework import status
+
+from wildlifelicensing.apps.returns.models import ReturnType
+from wildlifelicensing.apps.main.tests import helpers
+from wildlifelicensing.apps.returns.api.mixins import is_api_user
+
+
+class TestExplorerView(TestCase):
+    fixtures = [
+        'countries',
+        'groups',
+        'licences',
+        'conditions',
+        'default-conditions',
+        'returns'
+    ]
+
+    def test_authorisation(self):
+        """
+        Only superuser or API users
+        :return:
+        """
+        url = reverse("wl_returns:api:explorer")
+        customer = helpers.get_or_create_default_customer()
+        officer = helpers.get_or_create_default_officer()
+        assessor = helpers.get_or_create_default_assessor()
+
+        api_user = helpers.get_or_create_api_user()
+        self.assertTrue(is_api_user(api_user))
+
+        admin = helpers.create_random_customer()
+        admin.is_superuser = True
+        admin.save()
+        self.assertTrue(is_api_user(admin))
+
+        client = helpers.SocialClient()
+        forbidden = [customer, officer, assessor]
+        for user in forbidden:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_403_FORBIDDEN)
+            client.logout()
+
+        allowed = [admin, api_user]
+        for user in allowed:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_200_OK)
+            client.logout()
+
+
+class TestDataView(TestCase):
+    fixtures = [
+        'countries',
+        'groups',
+        'licences',
+        'conditions',
+        'default-conditions',
+        'returns'
+    ]
+
+    def setUp(self):
+        # should have at least on return type
+        self.return_type = ReturnType.objects.first()
+        self.assertIsNotNone(self.return_type)
+
+    def test_authorisation(self):
+        """
+        Only superuser or API users
+        :return:
+        """
+        url = reverse("wl_returns:api:data", kwargs={
+            'return_type_pk': self.return_type.pk,
+            'resource_number': 0
+        })
+        customer = helpers.get_or_create_default_customer()
+        officer = helpers.get_or_create_default_officer()
+        assessor = helpers.get_or_create_default_assessor()
+
+        api_user = helpers.get_or_create_api_user()
+        self.assertTrue(is_api_user(api_user))
+
+        admin = helpers.create_random_customer()
+        admin.is_superuser = True
+        admin.save()
+        self.assertTrue(is_api_user(admin))
+
+        client = helpers.SocialClient()
+        forbidden = [customer, officer, assessor]
+        for user in forbidden:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_403_FORBIDDEN)
+            client.logout()
+
+        allowed = [admin, api_user]
+        for user in allowed:
+            client.login(user.email)
+            self.assertEqual(client.get(url).status_code,
+                             status.HTTP_200_OK)
+            client.logout()

--- a/wildlifelicensing/apps/returns/tests/test_schema.py
+++ b/wildlifelicensing/apps/returns/tests/test_schema.py
@@ -1,0 +1,250 @@
+import datetime
+
+from django.utils import six
+from django.test import TestCase
+
+from wildlifelicensing.apps.returns.tests import helpers
+from wildlifelicensing.apps.returns.tests.helpers import BASE_CONSTRAINTS, clone, BASE_FIELD, REQUIRED_CONSTRAINTS
+from wildlifelicensing.apps.returns.utils_schema import SchemaConstraints, FieldSchemaError, SchemaField, Schema
+
+
+class TestSchemaConstraints(TestCase):
+    def test_none_or_empty(self):
+        """
+        None or empty is accepted
+        """
+        self.assertEquals({}, SchemaConstraints(None).data)
+        self.assertEquals({}, SchemaConstraints({}).data)
+
+    def test_required_property(self):
+        # no constraints -> require = False
+        self.assertFalse(SchemaConstraints(None).required)
+        cts = clone(BASE_CONSTRAINTS)
+        self.assertFalse(cts['required'])
+        self.assertFalse(SchemaConstraints(cts).required)
+
+        cts = clone(BASE_CONSTRAINTS)
+        cts['required'] = True
+        self.assertTrue(cts['required'])
+        self.assertTrue(SchemaConstraints(cts).required)
+
+    def test_get_method(self):
+        """
+        test that the SchemaField has the dict-like get('key', default)
+        """
+        cts = clone(BASE_CONSTRAINTS)
+        sch = SchemaConstraints(cts)
+        self.assertTrue(hasattr(sch, 'get'))
+        self.assertEquals(cts.get('required'), sch.get('required'))
+        self.assertEquals(cts.get('constraints'), sch.get('constraints'))
+        self.assertEquals(None, sch.get('bad_keys'))
+        self.assertEquals('default', sch.get('bad_keys', 'default'))
+
+
+class TestSchemaField(TestCase):
+    def setUp(self):
+        self.base_field = clone(BASE_FIELD)
+
+    def test_name_mandatory(self):
+        """
+        A schema field without name should throw an exception
+        """
+        field = self.base_field
+        del field['name']
+        with self.assertRaises(FieldSchemaError):
+            SchemaField(field)
+        # no blank
+        field = self.base_field
+        field['name'] = ''
+        with self.assertRaises(FieldSchemaError):
+            SchemaField(field)
+
+    def test_get_method(self):
+        """
+        test that the SchemaField has the dict-like get('key', default)
+        """
+        field = self.base_field
+        sch = SchemaField(field)
+        self.assertTrue(hasattr(sch, 'get'))
+        self.assertEquals(field.get('Name'), sch.get('Name'))
+        self.assertEquals(field.get('constraints'), sch.get('constraints'))
+        self.assertEquals(None, sch.get('bad_keys'))
+        self.assertEquals('default', sch.get('bad_keys', 'default'))
+
+    def test_column_name(self):
+        """
+        'column_name' is a property that is equal to name
+        """
+        field = self.base_field
+        sch = SchemaField(field)
+        self.assertEquals(sch.name, sch.column_name)
+        self.assertNotEqual(sch.column_name, sch.title)
+
+    def test_constraints(self):
+        """
+        test that the constraints property returned a SchemaConstraints
+        """
+        self.assertIsInstance(SchemaField(BASE_FIELD).constraints, SchemaConstraints)
+
+
+class TestSchemaFieldCast(TestCase):
+    def setUp(self):
+        self.base_field_descriptor = clone(BASE_FIELD)
+
+    def test_boolean(self):
+        true_values = [True, 'True', 'true', 'YES', 'yes', 'y', 't', '1', 1]
+        false_values = [False, 'FALSE', 'false', 'NO', 'no', 'n', 'f', '0', 0]
+        wrong_values = [2, 3, 'FLSE', 'flse', 'NON', 'oui', 'maybe', 'not sure']
+        descriptor = self.base_field_descriptor
+        descriptor['type'] = 'boolean'
+        # only 'default' format
+        descriptor['format'] = 'default'
+        f = SchemaField(descriptor)
+        for v in true_values:
+            self.assertTrue(f.cast(v))
+        for v in false_values:
+            self.assertFalse(f.cast(v))
+        for v in wrong_values:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+    def test_date(self):
+        descriptor = clone(BASE_FIELD)
+        descriptor['type'] = 'date'
+        # 'default' format = ISO
+        descriptor['format'] = 'default'
+        f = SchemaField(descriptor)
+        valid_values = ['2016-07-29']
+        for v in valid_values:
+            date = f.cast(v)
+            self.assertIsInstance(date, datetime.date)
+            self.assertEqual(datetime.date(2016, 7, 29), date)
+        invalid_value = ['29/07/2016', '07/29/2016', '2016-07-29 15:28:37']
+        for v in invalid_value:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+        # format='any'. 
+        # The main problem is to be sure that a dd/mm/yyyy is not interpreted as mm/dd/yyyy
+        descriptor['format'] = 'any'
+        f = SchemaField(descriptor)
+        valid_values = [
+            '2016-07-10',
+            '10/07/2016',
+            '10/07/16',
+            '2016-07-10 15:28:37',
+            '10-July-2016',
+            '10-JUlY-16',
+            '10-07-2016',
+            '10-07-16'
+        ]
+        expected_date = datetime.date(2016, 7, 10)
+        for v in valid_values:
+            date = f.cast(v)
+            self.assertIsInstance(date, datetime.date)
+            self.assertEqual(expected_date, date)
+        invalid_value = ['djskdj']
+        for v in invalid_value:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+    def test_date_custom_format(self):
+        format_ = 'fmt:%d %b %y'  # ex 30 Nov 14
+        descriptor = {
+            'name': 'Date with fmt',
+            'type': 'date',
+            'format': format_
+        }
+        field = SchemaField(descriptor)
+        value = '30 Nov 14'
+        self.assertEqual(field.cast(value), datetime.date(2014, 11, 30))
+
+    def test_string(self):
+        # test that a blank string '' is not accepted when the field is required
+        null_values = ['null', 'none', 'nil', 'nan', '-', '']
+        desc = clone(BASE_FIELD)
+        desc['type'] = 'string'
+        desc['constraints'] = clone(REQUIRED_CONSTRAINTS)
+        f = SchemaField(desc)
+        for v in null_values:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+        # test non unicode (python 2)
+        value = 'not unicode'
+        self.assertIsInstance(f.cast(value), six.text_type)
+        self.assertEqual(f.cast(value), value)
+
+    def test_datetime_any(self):
+        """
+        test datetime field with 'any' format
+        :return:
+        """
+        descriptor = clone(BASE_FIELD)
+        descriptor['type'] = 'datetime'
+        # format='any'.
+        # The main problem is to be sure that a dd/mm/yyyy is not interpreted as mm/dd/yyyy
+        descriptor['format'] = 'any'
+        f = SchemaField(descriptor)
+        valid_values = [
+            '2016-07-10 13:55:00',
+            '10/07/2016 13:55',
+            '10/07/16 1:55 pm',
+            '2016-07-10 13:55:00',
+            '10-July-2016 13:55:00',
+            '10-JUlY-16 13:55:00',
+            '10-07-2016 13:55:00',
+            '10-07-16 13:55:00'
+        ]
+        expected_dt = datetime.datetime(2016, 7, 10, 13, 55, 00)
+        for v in valid_values:
+            dt = f.cast(v)
+            self.assertIsInstance(dt, datetime.datetime)
+            self.assertEqual(expected_dt, dt)
+        invalid_value = ['djskdj']
+        for v in invalid_value:
+            with self.assertRaises(Exception):
+                f.cast(v)
+
+
+class TestSpeciesField(TestCase):
+
+    def test_no_species(self):
+        descriptor = clone(helpers.GENERIC_SCHEMA)
+        sch = Schema(descriptor)
+        # no species field
+        self.assertFalse(sch.species_fields)
+
+    def test_species_by_field_name(self):
+        """
+        A previous implementation supported species field detection by just the field name.
+        Not anymore
+        :return:
+        """
+        names = ['species name', 'Species Name', 'SPECIES_NAME', 'species_Name']
+        for name in names:
+            descriptor = clone(helpers.GENERIC_SCHEMA)
+            sch = Schema(descriptor)
+            # no species field
+            self.assertFalse(sch.species_fields)
+            # add a field named name
+            field = clone(BASE_FIELD)
+            field['name'] = name
+            descriptor['fields'].append(field)
+            sch = Schema(descriptor)
+            self.assertEqual(0, len(sch.species_fields))
+
+    def test_species_by_wl_tag(self):
+        # adding a wl species tag to a field turns it into a species field (whatever its name)
+        descriptor = clone(helpers.GENERIC_SCHEMA)
+        sch = Schema(descriptor)
+        # no species field
+        self.assertFalse(sch.species_fields)
+        # tag
+        field = descriptor['fields'][0]
+        field['wl'] = {
+            'type': 'species'
+        }
+        sch = Schema(descriptor)
+        self.assertEqual(1, len(sch.species_fields))
+        self.assertEquals(field['name'], sch.species_fields[0].name)


### PR DESCRIPTION
* [#1958 Species in returns](https://kanboard.dpaw.wa.gov.au/?controller=task&action=show&task_id=1958&project_id=24)  
When a field is 'tagged' as a species field in the schema of the `ReturnType`: 
* the return form will provide a type-ahead feature similar to the species field in application.
* if the form is pre-filled with species values (like after a an xlsx upload or a curate form), it provides a basic validation. The species field text will turn green if the name is valid.

Note: see the comment in the kanboard ticket on how to 'tag' a species field in the `Return Type` schema.
* Added help text as a licence (extracted) field.
Fixed bug with user account editing not saving.

* #1960 Add security on Return API

As discussed the API does't implement any Authentication mechanism other than the sessionId

* #2148 Missing fields in the report payment

* Product codes with variants now seperate with space

* Changed 'from Jim Sharp' to 'for Jim Sharp'

* Clear application data if selecting new licence type.

* Fix tests to run with -k by using dynamic fixture to create the Country AU

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/ledger/145)
<!-- Reviewable:end -->
